### PR TITLE
Add mobile store links with SVG placeholder logos

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1838,46 +1838,58 @@ input, select, textarea {
 		box-shadow: 0 0 0.15em 0 rgba(0, 0, 0, 0.1);
 	}
 
-		#header h1 {
-			position: absolute;
-			left: 1em;
-			top: 0;
-			height: 3em;
-			line-height: 3em;
-			cursor: default;
-		}
+                #header h1 {
+                        margin: 0 0 0 1em;
+                        line-height: 1;
+                        cursor: default;
+                }
 
 			#header h1 a {
 				font-size: 1.25em;
 			}
 
-		#header nav {
-			position: absolute;
-			right: 0.5em;
-			top: 0;
-			height: 3em;
-			line-height: 3em;
-		}
+                #header nav {
+                        position: absolute;
+                        right: 0.5em;
+                        top: 0;
+                        height: 3em;
+                        line-height: 3em;
+                }
 
-			#header nav ul {
-				margin: 0;
-			}
+                        #header nav ul {
+                                margin: 0;
+                        }
 
-				#header nav ul li {
-					display: inline-block;
-					margin-left: 0.5em;
-					font-size: 0.9em;
-				}
+                                #header nav ul li {
+                                        display: inline-block;
+                                        margin-left: 0.5em;
+                                        font-size: 0.9em;
+                                }
 
-					#header nav ul li a {
-						display: block;
-						color: inherit;
-						text-decoration: none;
-						height: 3em;
-						line-height: 3em;
-						padding: 0 0.5em 0 0.5em;
-						outline: 0;
-					}
+                                        #header nav ul li a {
+                                                display: block;
+                                                color: inherit;
+                                                text-decoration: none;
+                                                height: 3em;
+                                                line-height: 3em;
+                                                padding: 0 0.5em 0 0.5em;
+                                                outline: 0;
+                                        }
+
+                #header .branding {
+                        display: flex;
+                        align-items: center;
+                }
+
+                #header .store-links a {
+                        display: inline-block;
+                        margin-left: 0.5rem;
+                }
+
+                #header .store-links img {
+                        height: 2em;
+                        width: auto;
+                }
 
 		@media screen and (max-width: 736px) {
 
@@ -1886,14 +1898,11 @@ input, select, textarea {
 				line-height: 2.5em;
 			}
 
-				#header h1 {
-					text-align: center;
-					position: relative;
-					left: 0;
-					top: 0;
-					height: 2.5em;
-					line-height: 2.5em;
-				}
+                                #header h1 {
+                                        text-align: center;
+                                        margin-left: 0;
+                                        line-height: 1;
+                                }
 
 					#header h1 a {
 						font-size: 1em;

--- a/images/appstore-placeholder.svg
+++ b/images/appstore-placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="50" viewBox="0 0 150 50">
+  <rect width="150" height="50" fill="#cccccc" />
+  <text x="75" y="28" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#000000">App Store</text>
+</svg>

--- a/images/playstore-placeholder.svg
+++ b/images/playstore-placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="50" viewBox="0 0 150 50">
+  <rect width="150" height="50" fill="#cccccc" />
+  <text x="75" y="28" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#000000">Google Play</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -23,9 +23,21 @@
 	<body class="is-preload">
 
 		<!-- Header -->
-			<header id="header">
-				<h1>Get My Zen Place</h1>
-				<nav>
+                        <header id="header">
+                                <div class="branding">
+                                        <h1>Get My Zen Place</h1>
+                                       <div class="store-links">
+                                               <a href="https://apps.apple.com/us/app/my-zen-place/id6467138560"
+                                                  target="_blank" rel="noopener noreferrer">
+                                                       <img src="images/appstore-placeholder.svg" alt="Download on the App Store" class="store-link">
+                                               </a>
+                                               <a href="https://play.google.com/store/apps/details?id=com.myzenplace.app"
+                                                  target="_blank" rel="noopener noreferrer">
+                                                       <img src="images/playstore-placeholder.svg" alt="Get it on Google Play" class="store-link">
+                                               </a>
+                                       </div>
+                               </div>
+                                <nav>
 					<ul>
 						<li><a href="#intro">Welcome</a></li>
 						<li><a href="#one">About My Zen Place</a></li>


### PR DESCRIPTION
## Summary
- Wrap header text in a branding container with App Store and Google Play links that open in a new tab
- Add flex layout for header branding and store icons
- Replace binary placeholder badges with lightweight SVG images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cda24b1c083329f840cda23c0d3c9