### PR TITLE
Center store links vertically in header and add delimiter

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1876,20 +1876,26 @@ input, select, textarea {
                                                 outline: 0;
                                         }
 
-                #header .branding {
-                        display: flex;
-                        align-items: center;
-                }
+               #header .branding {
+                       display: flex;
+                       align-items: center;
+                       height: 100%;
+               }
 
-                #header .store-links a {
-                        display: inline-block;
-                        margin-left: 0.5rem;
-                }
+               #header .store-links {
+                       display: flex;
+                       align-items: center;
+               }
 
-                #header .store-links img {
-                        height: 2em;
-                        width: auto;
-                }
+               #header .store-links a {
+                       display: inline-block;
+                       margin-left: 0.5rem;
+               }
+
+               #header .store-links img {
+                       height: 2em;
+                       width: auto;
+               }
 
 		@media screen and (max-width: 736px) {
 

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 		<!-- Header -->
                         <header id="header">
                                 <div class="branding">
-                                        <h1>Get My Zen Place</h1>
+                                       <h1>Get My Zen Place |</h1>
                                        <div class="store-links">
                                                <a href="https://apps.apple.com/us/app/my-zen-place/id6467138560"
                                                   target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
## Summary
- Vertically center App Store and Google Play buttons in the header for consistent alignment.
- Add a `|` delimiter after "Get My Zen Place" to separate branding text from store links.

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ce166d67483328c7d4d0598d423b4