### PR TITLE
Add demo video to intro section with responsive styling

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2344,3 +2344,17 @@ input, select, textarea {
 			}
 
 		}
+.video-wrapper {
+	position: relative;
+	padding-bottom: 56.25%; /* 16:9 aspect ratio */
+	height: 0;
+	overflow: hidden;
+	max-width: 100%;
+}
+.video-wrapper iframe {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}

--- a/index.html
+++ b/index.html
@@ -53,12 +53,19 @@
 					<header>
 						<h2>Welcome</h2>
 					</header>
-					<p><strong>to your personalized haven for mindfulness, creativity, and sensory relief!</strong> 
-					<footer>
-						<a href="#one" class="button style2 down">More</a>
-					</footer>
-				</div>
-			</section>
+                                       <p><strong>to your personalized haven for mindfulness, creativity, and sensory relief!</strong></p>
+                                       <div class="video-wrapper">
+                                               <iframe src="https://www.youtube.com/embed/d7O5-YZnIww"
+                                                       title="My Zen Place Demo"
+                                                       frameborder="0"
+                                                       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                                       allowfullscreen></iframe>
+                                       </div>
+                                       <footer>
+                                               <a href="#one" class="button style2 down">More</a>
+                                       </footer>
+                               </div>
+                       </section>
 
 		<!-- One -->
 			<section id="one" class="main style2 right dark fullscreen">


### PR DESCRIPTION
## Summary
- Embed My Zen Place demo video in intro section.
- Add responsive CSS ensuring embedded video maintains 16:9 ratio and scales across devices.

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden)*
- `tidy -q -e index.html` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf280b3f08332b6dd4a6060c00dbb